### PR TITLE
Always use HTTPS scheme for USPS requests (avoids 301 redirect error)

### DIFF
--- a/lib/active_shipping/carriers/usps.rb
+++ b/lib/active_shipping/carriers/usps.rb
@@ -682,9 +682,9 @@ module ActiveShipping
     end
 
     def request_url(action, request, test)
-      scheme = USE_SSL[action] ? 'https://' : 'http://'
+      scheme = 'https://'
       host = test ? TEST_DOMAINS[USE_SSL[action]] : LIVE_DOMAIN
-      "#{scheme}#{host}/#{LIVE_RESOURCE}?API=#{API_CODES[action]}&XML=#{URI.encode(request)}"
+      "#{scheme}#{host}/#{LIVE_RESOURCE}?API=#{API_CODES[action]}&XML=#{CGI.escape(request)}"
     end
 
     def strip_zip(zip)

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "2.1.1"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
Additionally, use CGI.escape instead of URI.encode. This was breaking for me locally, I'm not sure why it wasn't breaking in production.